### PR TITLE
ci: ajoute une action commitlint

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,0 +1,45 @@
+{
+    "rules": {
+      "header-max-length": [
+        1,
+        "always",
+        100
+      ],
+      "subject-empty": [
+        1,
+        "never"
+      ],
+      "subject-full-stop": [
+        1,
+        "never",
+        "."
+      ],
+      "type-case": [
+        1,
+        "always",
+        "lower-case"
+      ],
+      "type-empty": [
+        1,
+        "never"
+      ],
+      "type-enum": [
+        1,
+        "always",
+        [
+          "breaking",
+          "build",
+          "chore",
+          "ci",
+          "config",
+          "docs",
+          "feat",
+          "fix",
+          "norelease",
+          "refactor",
+          "style",
+          "test"
+        ]
+      ]
+    }
+  }

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,14 @@
+name: Lint Commit Messages
+on: [pull_request, push]
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@v4
+        with:
+          failOnWarnings: true
+          configFile: .commitlintrc.json

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,3 +21,13 @@ Si vous voulez corriger une anomalie ou apporter une nouvelle fonctionnalité vo
 Consultez la [documentation développeur](docs/developer-guide.md) pour prendre en main ce dépôt.
 
 Attention, nous utilisons `commitlint` pour s'assurer que les messages de commit restent cohérents, avec l'objectif futur d'automatiser la publication de nouvelles release.  Les règles à suivre pour les messages de commit sont celles de [semantic-release](https://github.com/semantic-release/semantic-release)
+
+La première ligne des messages de commit doit se présenter sous la forme :
+
+`<type>(<scope>): <subject>`
+
+`<type>` est à choisir parmi une liste définie dans `.commitlintrc.json`. `<subject>` est un résumé de la modification. `<scope>` est optionnel.
+
+Exemple :
+
+`feat: ajout export CSV des rapports de validation`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,23 @@
+# Contribuer
+
+Merci d'envisager nous aider sur ce projet. Tout type de contribution est bienvenue
+
+# Contributions autres que du code
+
+N'hésitez pas à formuler toute proposition de nouvelle fonctionnalité, signalement d'anomalie ou même question dans une [nouvelle issue](https://github.com/IGNF/validator-api/issues/new/choose).
+
+Vous pouvez également parcourir les [issues existantes](https://github.com/IGNF/validator-api/issues) pour voir si le sujet n'a pas déjà été abordé.
+
+Enfin si vous pensez avoir cerné quel partie du validateur est concernée par votre contribution, vous pouvez créer l'issue dans le dépôt qui est le plus approprié parmi :
+
+* [IGNF/validator-api](https://github.com/IGNF/validator-api) : la surcouche API REST en PHP (le présent dépôt)
+* [IGNF/validator](https://github.com/IGNF/validator) : le moteur de validation en Java
+* [IGNF/validator-api-client](https://github.com/IGNF/validator-api-client/) : l'interface graphique du démonstrateur
+
+# Modifier le code ou la documentation
+
+Si vous voulez corriger une anomalie ou apporter une nouvelle fonctionnalité vous-même, faites ces modifications dans un fork du dépôt et soumettez-nous une [pull request](https://docs.github.com/fr/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)
+
+Consultez la [documentation développeur](docs/developer-guide.md) pour prendre en main ce dépôt.
+
+Attention, nous utilisons `commitlint` pour s'assurer que les messages de commit restent cohérents, avec l'objectif futur d'automatiser la publication de nouvelles release.  Les règles à suivre pour les messages de commit sont celles de [semantic-release](https://github.com/semantic-release/semantic-release)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Cette API permet d'appeler [IGNF/validator](https://github.com/IGNF/validator), outil permettant de valider et de normaliser les données présentes dans une arborescence de fichiers. [En savoir plus](https://github.com/IGNF/validator).
 
+## Documentation utilisateur
+
 * [Documentation utilisateur](docs/user-guide.md)
 
+## Documentation contributeur
+
+* [Comment contribuer ?](CONTRIBUTING.md)
 * [Documentation développeur](docs/developer-guide.md)


### PR DESCRIPTION
Je propose l'ajout d'une action commitlint à chaque push pour renforcer la cohérence des messages de commit.

Référence : https://www.conventionalcommits.org/en/v1.0.0/

Il reste à se mettre d'accord essentiellement sur les types de commits. J'ai copié la liste d'un autre projet open-source mais la liste me semble avoir des redondances ou des types dont nous n'avons pas l'usage : 

* `feat` : nouvelle fonctionnalité pour l'utilisateur (pas une nouvelle fonctionnalité dans un script de build)
* `fix` : correction de buf pour l'utilisateur (pas de correction de bug dans un script de build)
* `docs` : changements dans la documentation (docs, README, CONTRIBUTING...)
* `style` : formatage, point-virgules ou accolades manquantes... sans autre changement fonctionnel
* `refactor` : refactoring du code, renommages de classes, fonctions, variables...
* `test` : ajout de tests manquants, refactoring des tests sans autre changement fonctionnel
* `chore` : mise à jour de tâches npm, grunt... sans autre changement fonctionnel
* `ci` : changements dans la configuration des github actions et workflows, pourrait être considéré comme `chore`
* `build` : me semble redondant avec `chore` ou `ci`
* `config` : configuration de l'application elle-même et pas des scripts de build
* `norelease` : me semble inutile tant que semantic-versioning n'est pas branché derrière
* `breaking` : me semble inutile tant que semantic-versioning n'est pas branché derrière, surtout que conventional commits propose plutôt d'utiliser la notation BREAKING_CHANGE en footer du message de commit

L'intérêt de commitlint serait de pouvoir brancher ensuite la publication automatique de releases et packages : https://github.com/semantic-release/semantic-release
